### PR TITLE
Alphabet for NgramCounter and NgramFrequency

### DIFF
--- a/crypto_tools/stats/ngram_counter.py
+++ b/crypto_tools/stats/ngram_counter.py
@@ -33,8 +33,6 @@ class NgramCounter:
             else:
                 text = self.text
             for position, character in enumerate(text[:-self.nvalue + 1]):
-                if self.counter == {}:
-                    print(text[position:position + self.nvalue])
                 if not string_utils.has_whitespace(text[position:position + self.nvalue]):
                     if not string_utils.includes_other_letters(text[position:position + self.nvalue], self.alphabet):
                         if text[position:position + self.nvalue].lower() not in self.counter.keys():

--- a/crypto_tools/stats/ngram_counter.py
+++ b/crypto_tools/stats/ngram_counter.py
@@ -2,17 +2,24 @@ from ..utils import string_utils
 
 
 class NgramCounter:
-    def __init__(self, nvalue=2, text="", joined=True):
-        self.text = text
+    def __init__(self, nvalue=2, text="", joined=True, alphabet="abcdefghijklmnopqrstuvwxyz", lower=True):
+        if lower:
+            self.text = text.lower()
+        else:
+            self.text = text
         self.nvalue = int(nvalue)
         self.joined = joined
         self.counter = {}
+        self.alphabet = alphabet
+        self.lower = lower
 
     def __repr__(self):
-        return 'NgramCounter(nvalue={nvalue}, text={text}, joined={joined})'.format(
+        return 'NgramCounter(nvalue={nvalue}, text={text}, joined={joined}, alphabet={alphabet}, lower={lower})'.format(
             nvalue=self.nvalue,
             text=self.text,
-            joined=self.joined
+            joined=self.joined,
+            alphabet=self.alphabet,
+            lower=self.lower
         )
 
     def __str__(self):
@@ -26,11 +33,14 @@ class NgramCounter:
             else:
                 text = self.text
             for position, character in enumerate(text[:-self.nvalue + 1]):
+                if self.counter == {}:
+                    print(text[position:position + self.nvalue])
                 if not string_utils.has_whitespace(text[position:position + self.nvalue]):
-                    if text[position:position + self.nvalue].lower() not in self.counter.keys():
-                        self.counter[text[position:position + self.nvalue].lower()] = 1
-                    else:
-                        self.counter[text[position:position + self.nvalue].lower()] += 1
+                    if not string_utils.includes_other_letters(text[position:position + self.nvalue], self.alphabet):
+                        if text[position:position + self.nvalue].lower() not in self.counter.keys():
+                            self.counter[text[position:position + self.nvalue].lower()] = 1
+                        else:
+                            self.counter[text[position:position + self.nvalue].lower()] += 1
         return self.counter
 
     def set_text(self, text):

--- a/crypto_tools/stats/ngram_frequency.py
+++ b/crypto_tools/stats/ngram_frequency.py
@@ -2,18 +2,27 @@ from .ngram_counter import NgramCounter
 
 
 class NgramFrequency:
-    def __init__(self, nvalue=2, text="", joined=True):
+    def __init__(self, nvalue=2, text="", joined=True, alphabet="abcdefghijklmnopqrstuvwxyz", lower=True):
+        if lower:
+            self.text = text.lower()
+        else:
+            self.text = text
         self.text = text
         self.nvalue = int(nvalue)
         self.joined = joined
         self.frequency = {}
-        self.ngram_count = NgramCounter(nvalue=nvalue, text=text, joined=joined)
+        self.ngram_count = NgramCounter(nvalue=nvalue, text=text, joined=joined, alphabet=alphabet, lower=lower)
+        self.alphabet = alphabet
+        self.lower = lower
 
     def __repr__(self):
-        return 'NgramFrequency(nvalue={nvalue}, text={text}, joined={joined})'.format(
-            nvalue=self.nvalue,
-            text=self.text,
-            joined=self.joined
+        return 'NgramFrequency(nvalue={nvalue}, text={text}, joined={joined}, alphabet={alphabet}, lower={lower})'\
+            .format(
+                nvalue=self.nvalue,
+                text=self.text,
+                joined=self.joined,
+                alphabet=self.alphabet,
+                lower=self.lower
         )
 
     def __str__(self):

--- a/crypto_tools/utils/string_utils.py
+++ b/crypto_tools/utils/string_utils.py
@@ -6,3 +6,10 @@ def has_whitespace(text):
         if character in whitespace:
             return True
     return False
+
+
+def includes_other_letters(text, allowed):
+    for character in text:
+        if character not in allowed:
+            return True
+    return False

--- a/tests/test_ngram_counter.py
+++ b/tests/test_ngram_counter.py
@@ -77,6 +77,42 @@ class TestNgramCounter(unittest.TestCase):
         }
         self.assertEqual(counter, correct)
 
+    def test_count_text_with_nonalphabetic_characters(self):
+        text = "The quick, brown fox jumps over the lazy dog!"
+        counter = ngram_counter.NgramCounter(nvalue=4, text=text, joined=True).count()
+        correct={
+            "theq": 1,
+            "hequ": 1,
+            "equi": 1,
+            "quic": 1,
+            "uick": 1,
+            "brow": 1,
+            "rown": 1,
+            "ownf": 1,
+            "wnfo": 1,
+            "nfox": 1,
+            "foxj": 1,
+            "oxju": 1,
+            "xjum": 1,
+            "jump": 1,
+            "umps": 1,
+            "mpso": 1,
+            "psov": 1,
+            "sove": 1,
+            "over": 1,
+            "vert": 1,
+            "erth": 1,
+            "rthe": 1,
+            "thel": 1,
+            "hela": 1,
+            "elaz": 1,
+            "lazy": 1,
+            "azyd": 1,
+            "zydo": 1,
+            "ydog": 1
+        }
+        self.assertEqual(counter, correct)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #31 

Non alphabetic characters are avoided by default by NgramCounter and NgramFrequency.
A different alphabet can still be specified.